### PR TITLE
Add console migrator for database setup

### DIFF
--- a/backend/POS.sln
+++ b/backend/POS.sln
@@ -14,12 +14,18 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "POS.Infrastructure", "src\P
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "POS.WebAPI", "src\POS.WebAPI\POS.WebAPI.csproj", "{BBF31BD3-0DFD-4D2D-A217-D6F2DEA80997}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "POS.Migrator", "src\POS.Migrator\POS.Migrator.csproj", "{F9D5A3ED-DC43-48F5-9B57-28722E8F495A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F9D5A3ED-DC43-48F5-9B57-28722E8F495A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9D5A3ED-DC43-48F5-9B57-28722E8F495A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9D5A3ED-DC43-48F5-9B57-28722E8F495A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9D5A3ED-DC43-48F5-9B57-28722E8F495A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B37C7C76-8A5A-4741-9CBF-C4CAC496708E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B37C7C76-8A5A-4741-9CBF-C4CAC496708E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B37C7C76-8A5A-4741-9CBF-C4CAC496708E}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/backend/README.md
+++ b/backend/README.md
@@ -189,3 +189,12 @@ Proprietary - Cookie Barrel Pty Ltd
 
 ## Contact
 For support, contact: support@cookiebarrel.com.au
+
+### Running Database Migrations via Console
+```bash
+cd backend/src/POS.Migrator
+# Update the connection string in appsettings.json if needed
+dotnet run
+```
+
+This console application applies pending Entity Framework Core migrations and seeds default data using the same configuration as the API.

--- a/backend/src/POS.Migrator/POS.Migrator.csproj
+++ b/backend/src/POS.Migrator/POS.Migrator.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\POS.Infrastructure\POS.Infrastructure.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/backend/src/POS.Migrator/Program.cs
+++ b/backend/src/POS.Migrator/Program.cs
@@ -1,0 +1,69 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using POS.Infrastructure.Data;
+using POS.Infrastructure.Data.Seeders;
+using System.IO;
+
+var webApiProjectPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory,
+    "..", "..", "..", "..", "..", "src", "POS.WebAPI"));
+
+if (Directory.Exists(webApiProjectPath))
+{
+    Directory.SetCurrentDirectory(webApiProjectPath);
+}
+else
+{
+    Console.WriteLine($"Warning: Expected WebAPI project directory not found at {webApiProjectPath}. Relative paths may not resolve correctly.");
+}
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Configuration.AddJsonFile("appsettings.json", optional: true)
+                     .AddJsonFile("appsettings.Development.json", optional: true)
+                     .AddEnvironmentVariables();
+
+builder.Services.AddLogging(logging =>
+{
+    logging.ClearProviders();
+    logging.AddConsole();
+});
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+if (string.IsNullOrWhiteSpace(connectionString))
+{
+    throw new InvalidOperationException("The DefaultConnection connection string is not configured.");
+}
+
+builder.Services.AddDbContext<POSDbContext>(options =>
+    options.UseSqlServer(
+        connectionString,
+        b => b.MigrationsAssembly(typeof(POSDbContext).Assembly.FullName)));
+
+builder.Services.AddScoped<DatabaseSeeder>();
+
+await using var host = builder.Build();
+
+await using var scope = host.Services.CreateAsyncScope();
+var serviceProvider = scope.ServiceProvider;
+var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Migrator");
+
+try
+{
+    var dbContext = serviceProvider.GetRequiredService<POSDbContext>();
+    logger.LogInformation("Starting database migration...");
+    await dbContext.Database.MigrateAsync();
+    logger.LogInformation("Database migrated successfully.");
+
+    var seeder = serviceProvider.GetRequiredService<DatabaseSeeder>();
+    logger.LogInformation("Starting database seeding...");
+    await seeder.SeedAsync();
+    logger.LogInformation("Database seeded successfully.");
+}
+catch (Exception ex)
+{
+    logger.LogError(ex, "An error occurred while migrating or seeding the database.");
+    Environment.ExitCode = 1;
+}

--- a/backend/src/POS.Migrator/appsettings.json
+++ b/backend/src/POS.Migrator/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=POSDatabase;Trusted_Connection=True;MultipleActiveResultSets=true"
+  }
+}


### PR DESCRIPTION
## Summary
- add a new POS.Migrator console project that applies EF Core migrations and seeds data using the infrastructure layer
- copy the console configuration to the output and wire the project into the solution so it can be built with the rest of the backend
- document how to run the migrator from the command line

## Testing
- dotnet commands are unavailable in the execution environment

------
https://chatgpt.com/codex/tasks/task_e_68ce0176122483308440a1763799e718