### PR TITLE
Configure Shift relationships

### DIFF
--- a/backend/src/POS.Infrastructure/Data/Configurations/ShiftConfiguration.cs
+++ b/backend/src/POS.Infrastructure/Data/Configurations/ShiftConfiguration.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using POS.Domain.Entities;
+
+namespace POS.Infrastructure.Data.Configurations;
+
+public class ShiftConfiguration : IEntityTypeConfiguration<Shift>
+{
+    public void Configure(EntityTypeBuilder<Shift> builder)
+    {
+        builder.HasOne(s => s.User)
+            .WithMany(u => u.Shifts)
+            .HasForeignKey(s => s.UserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(s => s.ClosedByUser)
+            .WithMany()
+            .HasForeignKey(s => s.ClosedByUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}


### PR DESCRIPTION
## Summary
- configure the Shift entity relationships to User and ClosedByUser
- prevent cascading delete conflicts by restricting deletions on those links

## Testing
- dotnet build POS.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ce008c2ca883308f6becae397c4c25