### PR TITLE
Handle invalid user id claims gracefully

### DIFF
--- a/backend/src/POS.WebAPI/Services/CurrentUserService.cs
+++ b/backend/src/POS.WebAPI/Services/CurrentUserService.cs
@@ -17,7 +17,15 @@ public class CurrentUserService : ICurrentUserService
         get
         {
             var userIdClaim = _httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-            return string.IsNullOrEmpty(userIdClaim) ? null : long.Parse(userIdClaim);
+
+            if (string.IsNullOrWhiteSpace(userIdClaim))
+            {
+                return null;
+            }
+
+            return long.TryParse(userIdClaim, out var userId)
+                ? userId
+                : null;
         }
     }
 


### PR DESCRIPTION
## Summary
- prevent CurrentUserService from throwing when the user id claim is missing or non-numeric by using long.TryParse

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce0097237c8330957df72ec0aa7381