### PR TITLE
Add hosting dependency for migrator project

### DIFF
--- a/backend/src/POS.Migrator/POS.Migrator.csproj
+++ b/backend/src/POS.Migrator/POS.Migrator.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\POS.Infrastructure\POS.Infrastructure.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add the Microsoft.Extensions.Hosting package reference to the migrator project so the Host APIs are available

## Testing
- dotnet build POS.sln *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce042f134c8330b30960a61cebb12d