### PR TITLE
Fix POS migrator dependency registration

### DIFF
--- a/backend/src/POS.Migrator/Program.cs
+++ b/backend/src/POS.Migrator/Program.cs
@@ -4,7 +4,10 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using POS.Infrastructure.Data;
+using POS.Infrastructure.Data.Interceptors;
 using POS.Infrastructure.Data.Seeders;
+using POS.Infrastructure.Services;
+using POS.Migrator.Services;
 using System.IO;
 
 var webApiProjectPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory,
@@ -42,6 +45,9 @@ builder.Services.AddDbContext<POSDbContext>(options =>
         connectionString,
         b => b.MigrationsAssembly(typeof(POSDbContext).Assembly.FullName)));
 
+builder.Services.AddScoped<ICurrentUserService, MigratorCurrentUserService>();
+builder.Services.AddScoped<IDateTimeService, DateTimeService>();
+builder.Services.AddScoped<AuditableEntitySaveChangesInterceptor>();
 builder.Services.AddScoped<DatabaseSeeder>();
 
 await using var host = builder.Build();

--- a/backend/src/POS.Migrator/Services/MigratorCurrentUserService.cs
+++ b/backend/src/POS.Migrator/Services/MigratorCurrentUserService.cs
@@ -1,0 +1,12 @@
+using POS.Infrastructure.Data.Interceptors;
+
+namespace POS.Migrator.Services;
+
+public class MigratorCurrentUserService : ICurrentUserService
+{
+    public long? UserId => null;
+
+    public string? Username => "Migrator";
+
+    public string? Email => null;
+}


### PR DESCRIPTION
## Summary
- register the auditing interceptor and its dependencies in the migrator host
- add a console-friendly current user service implementation for database migrations

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ce0690bf3c8330816222df8597340e