### PR TITLE
Configure decimal precision and add initial migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ artifacts/
 *.ldf
 *.ndf
 Migrations/
+!backend/src/POS.Infrastructure/Data/Migrations/
+!backend/src/POS.Infrastructure/Data/Migrations/**
 
 ## SQL Server files
 *.mdf

--- a/backend/src/POS.Infrastructure/Data/Configurations/CustomerConfiguration.cs
+++ b/backend/src/POS.Infrastructure/Data/Configurations/CustomerConfiguration.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using POS.Domain.Entities;
+
+namespace POS.Infrastructure.Data.Configurations;
+
+public class CustomerConfiguration : IEntityTypeConfiguration<Customer>
+{
+    public void Configure(EntityTypeBuilder<Customer> builder)
+    {
+        builder.Property(e => e.TotalPurchases)
+            .HasPrecision(18, 2);
+    }
+}

--- a/backend/src/POS.Infrastructure/Data/Configurations/InventoryTransactionConfiguration.cs
+++ b/backend/src/POS.Infrastructure/Data/Configurations/InventoryTransactionConfiguration.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using POS.Domain.Entities;
+
+namespace POS.Infrastructure.Data.Configurations;
+
+public class InventoryTransactionConfiguration : IEntityTypeConfiguration<InventoryTransaction>
+{
+    public void Configure(EntityTypeBuilder<InventoryTransaction> builder)
+    {
+        builder.Property(e => e.UnitCost)
+            .HasPrecision(18, 2);
+
+        builder.Property(e => e.TotalCost)
+            .HasPrecision(18, 2);
+    }
+}

--- a/backend/src/POS.Infrastructure/Data/Configurations/OrderItemConfiguration.cs
+++ b/backend/src/POS.Infrastructure/Data/Configurations/OrderItemConfiguration.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using POS.Domain.Entities;
+
+namespace POS.Infrastructure.Data.Configurations;
+
+public class OrderItemConfiguration : IEntityTypeConfiguration<OrderItem>
+{
+    public void Configure(EntityTypeBuilder<OrderItem> builder)
+    {
+        builder.Property(e => e.UnitPriceExGst)
+            .HasPrecision(18, 2);
+
+        builder.Property(e => e.UnitGstAmount)
+            .HasPrecision(18, 2);
+
+        builder.Property(e => e.UnitPriceIncGst)
+            .HasPrecision(18, 2);
+
+        builder.Property(e => e.DiscountAmount)
+            .HasPrecision(18, 2);
+
+        builder.Property(e => e.SubTotal)
+            .HasPrecision(18, 2);
+
+        builder.Property(e => e.TaxAmount)
+            .HasPrecision(18, 2);
+
+        builder.Property(e => e.TotalAmount)
+            .HasPrecision(18, 2);
+    }
+}

--- a/backend/src/POS.Infrastructure/Data/Configurations/PaymentConfiguration.cs
+++ b/backend/src/POS.Infrastructure/Data/Configurations/PaymentConfiguration.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using POS.Domain.Entities;
+
+namespace POS.Infrastructure.Data.Configurations;
+
+public class PaymentConfiguration : IEntityTypeConfiguration<Payment>
+{
+    public void Configure(EntityTypeBuilder<Payment> builder)
+    {
+        builder.Property(e => e.Amount)
+            .HasPrecision(18, 2);
+    }
+}

--- a/backend/src/POS.Infrastructure/Data/Configurations/ShiftConfiguration.cs
+++ b/backend/src/POS.Infrastructure/Data/Configurations/ShiftConfiguration.cs
@@ -8,6 +8,24 @@ public class ShiftConfiguration : IEntityTypeConfiguration<Shift>
 {
     public void Configure(EntityTypeBuilder<Shift> builder)
     {
+        builder.Property(e => e.StartingCash)
+            .HasPrecision(18, 2);
+
+        builder.Property(e => e.EndingCash)
+            .HasPrecision(18, 2);
+
+        builder.Property(e => e.CashSales)
+            .HasPrecision(18, 2);
+
+        builder.Property(e => e.CardSales)
+            .HasPrecision(18, 2);
+
+        builder.Property(e => e.OtherSales)
+            .HasPrecision(18, 2);
+
+        builder.Property(e => e.TotalSales)
+            .HasPrecision(18, 2);
+
         builder.HasOne(s => s.User)
             .WithMany(u => u.Shifts)
             .HasForeignKey(s => s.UserId)

--- a/backend/src/POS.Infrastructure/Data/Configurations/StoreConfiguration.cs
+++ b/backend/src/POS.Infrastructure/Data/Configurations/StoreConfiguration.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using POS.Domain.Entities;
+
+namespace POS.Infrastructure.Data.Configurations;
+
+public class StoreConfiguration : IEntityTypeConfiguration<Store>
+{
+    public void Configure(EntityTypeBuilder<Store> builder)
+    {
+        builder.Property(e => e.TaxRate)
+            .HasPrecision(5, 4);
+    }
+}

--- a/backend/src/POS.Infrastructure/Data/Migrations/20241007000000_InitialCreate.cs
+++ b/backend/src/POS.Infrastructure/Data/Migrations/20241007000000_InitialCreate.cs
@@ -1,0 +1,720 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace POS.Infrastructure.Data.Migrations;
+
+public partial class InitialCreate : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "Categories",
+            columns: table => new
+            {
+                Id = table.Column<long>(type: "bigint", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                Slug = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                Description = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                DisplayOrder = table.Column<int>(type: "int", nullable: false),
+                IsActive = table.Column<bool>(type: "bit", nullable: false),
+                CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
+                CreatedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                ModifiedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                ModifiedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                DeletedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                DeletedByUserId = table.Column<long>(type: "bigint", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Categories", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Customers",
+            columns: table => new
+            {
+                Id = table.Column<long>(type: "bigint", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                FirstName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                LastName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Email = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                Phone = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                Address = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                City = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                State = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                PostalCode = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                Country = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                DateOfBirth = table.Column<DateTime>(type: "datetime2", nullable: true),
+                Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                IsActive = table.Column<bool>(type: "bit", nullable: false),
+                TotalPurchases = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                TotalOrders = table.Column<int>(type: "int", nullable: false),
+                LastOrderDate = table.Column<DateTime>(type: "datetime2", nullable: true),
+                LoyaltyCardNumber = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                LoyaltyPoints = table.Column<int>(type: "int", nullable: false),
+                CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false),
+                CreatedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                ModifiedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                ModifiedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                DeletedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                DeletedByUserId = table.Column<long>(type: "bigint", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Customers", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Stores",
+            columns: table => new
+            {
+                Id = table.Column<long>(type: "bigint", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Code = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Address = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                City = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                State = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                PostalCode = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                Country = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                Phone = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                Email = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                TaxNumber = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                TaxRate = table.Column<decimal>(type: "decimal(5,4)", precision: 5, scale: 4, nullable: false),
+                Currency = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                IsActive = table.Column<bool>(type: "bit", nullable: false),
+                OpeningTime = table.Column<TimeSpan>(type: "time", nullable: true),
+                ClosingTime = table.Column<TimeSpan>(type: "time", nullable: true),
+                CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false),
+                CreatedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                ModifiedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                ModifiedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                DeletedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                DeletedByUserId = table.Column<long>(type: "bigint", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Stores", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Suppliers",
+            columns: table => new
+            {
+                Id = table.Column<long>(type: "bigint", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                ContactPerson = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                Email = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                Phone = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                Address = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                City = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                State = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                PostalCode = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                Country = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                TaxNumber = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                IsActive = table.Column<bool>(type: "bit", nullable: false),
+                CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false),
+                CreatedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                ModifiedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                ModifiedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                DeletedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                DeletedByUserId = table.Column<long>(type: "bigint", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Suppliers", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Subcategories",
+            columns: table => new
+            {
+                Id = table.Column<long>(type: "bigint", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Slug = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                DisplayOrder = table.Column<int>(type: "int", nullable: false),
+                IsActive = table.Column<bool>(type: "bit", nullable: false),
+                CategoryId = table.Column<long>(type: "bigint", nullable: false),
+                CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false),
+                CreatedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                ModifiedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                ModifiedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                DeletedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                DeletedByUserId = table.Column<long>(type: "bigint", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Subcategories", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Subcategories_Categories_CategoryId",
+                    column: x => x.CategoryId,
+                    principalTable: "Categories",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Users",
+            columns: table => new
+            {
+                Id = table.Column<long>(type: "bigint", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                Username = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                Email = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                PasswordHash = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                FirstName = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                LastName = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                Phone = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: true),
+                Pin = table.Column<string>(type: "nvarchar(10)", maxLength: 10, nullable: true),
+                Role = table.Column<int>(type: "int", nullable: false),
+                IsActive = table.Column<bool>(type: "bit", nullable: false),
+                LastLoginAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                RefreshToken = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                RefreshTokenExpiryTime = table.Column<DateTime>(type: "datetime2", nullable: true),
+                StoreId = table.Column<long>(type: "bigint", nullable: true),
+                CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
+                CreatedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                ModifiedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                ModifiedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                DeletedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                DeletedByUserId = table.Column<long>(type: "bigint", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Users", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Users_Stores_StoreId",
+                    column: x => x.StoreId,
+                    principalTable: "Stores",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.SetNull);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Products",
+            columns: table => new
+            {
+                Id = table.Column<long>(type: "bigint", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                Slug = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                SKU = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                Barcode = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                Description = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: true),
+                PriceExGst = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                GstAmount = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                PriceIncGst = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                Cost = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: true),
+                PackNotes = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                PackSize = table.Column<int>(type: "int", nullable: true),
+                ImageUrl = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                IsActive = table.Column<bool>(type: "bit", nullable: false),
+                TrackInventory = table.Column<bool>(type: "bit", nullable: false),
+                StockQuantity = table.Column<int>(type: "int", nullable: false),
+                LowStockThreshold = table.Column<int>(type: "int", nullable: false),
+                DisplayOrder = table.Column<int>(type: "int", nullable: false),
+                SubcategoryId = table.Column<long>(type: "bigint", nullable: false),
+                SupplierId = table.Column<long>(type: "bigint", nullable: true),
+                CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
+                CreatedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                ModifiedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                ModifiedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                DeletedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                DeletedByUserId = table.Column<long>(type: "bigint", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Products", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Products_Subcategories_SubcategoryId",
+                    column: x => x.SubcategoryId,
+                    principalTable: "Subcategories",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+                table.ForeignKey(
+                    name: "FK_Products_Suppliers_SupplierId",
+                    column: x => x.SupplierId,
+                    principalTable: "Suppliers",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.SetNull);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Shifts",
+            columns: table => new
+            {
+                Id = table.Column<long>(type: "bigint", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                ShiftNumber = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                StartTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                EndTime = table.Column<DateTime>(type: "datetime2", nullable: true),
+                StartingCash = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                EndingCash = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: true),
+                CashSales = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: true),
+                CardSales = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: true),
+                OtherSales = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: true),
+                TotalSales = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: true),
+                TotalOrders = table.Column<int>(type: "int", nullable: true),
+                Status = table.Column<int>(type: "int", nullable: false),
+                Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                UserId = table.Column<long>(type: "bigint", nullable: false),
+                StoreId = table.Column<long>(type: "bigint", nullable: false),
+                ClosedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false),
+                CreatedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                ModifiedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                ModifiedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                DeletedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                DeletedByUserId = table.Column<long>(type: "bigint", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Shifts", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Shifts_Stores_StoreId",
+                    column: x => x.StoreId,
+                    principalTable: "Stores",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+                table.ForeignKey(
+                    name: "FK_Shifts_Users_ClosedByUserId",
+                    column: x => x.ClosedByUserId,
+                    principalTable: "Users",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+                table.ForeignKey(
+                    name: "FK_Shifts_Users_UserId",
+                    column: x => x.UserId,
+                    principalTable: "Users",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Orders",
+            columns: table => new
+            {
+                Id = table.Column<long>(type: "bigint", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                OrderNumber = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                OrderDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                Status = table.Column<int>(type: "int", nullable: false),
+                OrderType = table.Column<int>(type: "int", nullable: false),
+                SubTotal = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                DiscountAmount = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                TaxAmount = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                TotalAmount = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                PaidAmount = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                ChangeAmount = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                Notes = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                TableNumber = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: true),
+                CompletedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                CancelledAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                CancellationReason = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                CustomerId = table.Column<long>(type: "bigint", nullable: true),
+                StoreId = table.Column<long>(type: "bigint", nullable: false),
+                UserId = table.Column<long>(type: "bigint", nullable: false),
+                ShiftId = table.Column<long>(type: "bigint", nullable: true),
+                CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
+                CreatedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                ModifiedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                ModifiedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                DeletedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                DeletedByUserId = table.Column<long>(type: "bigint", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Orders", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Orders_Customers_CustomerId",
+                    column: x => x.CustomerId,
+                    principalTable: "Customers",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.SetNull);
+                table.ForeignKey(
+                    name: "FK_Orders_Shifts_ShiftId",
+                    column: x => x.ShiftId,
+                    principalTable: "Shifts",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.SetNull);
+                table.ForeignKey(
+                    name: "FK_Orders_Stores_StoreId",
+                    column: x => x.StoreId,
+                    principalTable: "Stores",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+                table.ForeignKey(
+                    name: "FK_Orders_Users_UserId",
+                    column: x => x.UserId,
+                    principalTable: "Users",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "InventoryTransactions",
+            columns: table => new
+            {
+                Id = table.Column<long>(type: "bigint", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                TransactionType = table.Column<int>(type: "int", nullable: false),
+                Quantity = table.Column<int>(type: "int", nullable: false),
+                StockBefore = table.Column<int>(type: "int", nullable: false),
+                StockAfter = table.Column<int>(type: "int", nullable: false),
+                UnitCost = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: true),
+                TotalCost = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: true),
+                ReferenceNumber = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                TransactionDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                ProductId = table.Column<long>(type: "bigint", nullable: false),
+                StoreId = table.Column<long>(type: "bigint", nullable: false),
+                UserId = table.Column<long>(type: "bigint", nullable: false),
+                OrderId = table.Column<long>(type: "bigint", nullable: true),
+                SupplierId = table.Column<long>(type: "bigint", nullable: true),
+                CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false),
+                CreatedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                ModifiedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                ModifiedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                DeletedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                DeletedByUserId = table.Column<long>(type: "bigint", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_InventoryTransactions", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_InventoryTransactions_Orders_OrderId",
+                    column: x => x.OrderId,
+                    principalTable: "Orders",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+                table.ForeignKey(
+                    name: "FK_InventoryTransactions_Products_ProductId",
+                    column: x => x.ProductId,
+                    principalTable: "Products",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+                table.ForeignKey(
+                    name: "FK_InventoryTransactions_Stores_StoreId",
+                    column: x => x.StoreId,
+                    principalTable: "Stores",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+                table.ForeignKey(
+                    name: "FK_InventoryTransactions_Suppliers_SupplierId",
+                    column: x => x.SupplierId,
+                    principalTable: "Suppliers",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.SetNull);
+                table.ForeignKey(
+                    name: "FK_InventoryTransactions_Users_UserId",
+                    column: x => x.UserId,
+                    principalTable: "Users",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "OrderItems",
+            columns: table => new
+            {
+                Id = table.Column<long>(type: "bigint", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                Quantity = table.Column<int>(type: "int", nullable: false),
+                UnitPriceExGst = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                UnitGstAmount = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                UnitPriceIncGst = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                DiscountAmount = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                SubTotal = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                TaxAmount = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                TotalAmount = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                IsVoided = table.Column<bool>(type: "bit", nullable: false),
+                VoidedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                VoidReason = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                OrderId = table.Column<long>(type: "bigint", nullable: false),
+                ProductId = table.Column<long>(type: "bigint", nullable: false),
+                VoidedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false),
+                CreatedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                ModifiedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                ModifiedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                DeletedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                DeletedByUserId = table.Column<long>(type: "bigint", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_OrderItems", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_OrderItems_Orders_OrderId",
+                    column: x => x.OrderId,
+                    principalTable: "Orders",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_OrderItems_Products_ProductId",
+                    column: x => x.ProductId,
+                    principalTable: "Products",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+                table.ForeignKey(
+                    name: "FK_OrderItems_Users_VoidedByUserId",
+                    column: x => x.VoidedByUserId,
+                    principalTable: "Users",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Payments",
+            columns: table => new
+            {
+                Id = table.Column<long>(type: "bigint", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                Amount = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                PaymentMethod = table.Column<int>(type: "int", nullable: false),
+                Status = table.Column<int>(type: "int", nullable: false),
+                ReferenceNumber = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                CardLastFourDigits = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                CardType = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                PaymentDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                OrderId = table.Column<long>(type: "bigint", nullable: false),
+                ProcessedByUserId = table.Column<long>(type: "bigint", nullable: false),
+                CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false),
+                CreatedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                ModifiedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                ModifiedByUserId = table.Column<long>(type: "bigint", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                DeletedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                DeletedByUserId = table.Column<long>(type: "bigint", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Payments", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Payments_Orders_OrderId",
+                    column: x => x.OrderId,
+                    principalTable: "Orders",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+                table.ForeignKey(
+                    name: "FK_Payments_Users_ProcessedByUserId",
+                    column: x => x.ProcessedByUserId,
+                    principalTable: "Users",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Categories_Slug",
+            table: "Categories",
+            column: "Slug",
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_InventoryTransactions_OrderId",
+            table: "InventoryTransactions",
+            column: "OrderId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_InventoryTransactions_ProductId",
+            table: "InventoryTransactions",
+            column: "ProductId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_InventoryTransactions_StoreId",
+            table: "InventoryTransactions",
+            column: "StoreId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_InventoryTransactions_SupplierId",
+            table: "InventoryTransactions",
+            column: "SupplierId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_InventoryTransactions_UserId",
+            table: "InventoryTransactions",
+            column: "UserId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_OrderItems_OrderId",
+            table: "OrderItems",
+            column: "OrderId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_OrderItems_ProductId",
+            table: "OrderItems",
+            column: "ProductId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_OrderItems_VoidedByUserId",
+            table: "OrderItems",
+            column: "VoidedByUserId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Orders_CustomerId",
+            table: "Orders",
+            column: "CustomerId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Orders_OrderDate",
+            table: "Orders",
+            column: "OrderDate");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Orders_OrderNumber",
+            table: "Orders",
+            column: "OrderNumber",
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Orders_ShiftId",
+            table: "Orders",
+            column: "ShiftId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Orders_StoreId_OrderDate",
+            table: "Orders",
+            columns: new[] { "StoreId", "OrderDate" });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Orders_UserId",
+            table: "Orders",
+            column: "UserId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Payments_OrderId",
+            table: "Payments",
+            column: "OrderId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Payments_ProcessedByUserId",
+            table: "Payments",
+            column: "ProcessedByUserId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Products_Barcode",
+            table: "Products",
+            column: "Barcode",
+            unique: true,
+            filter: "[Barcode] IS NOT NULL");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Products_SKU",
+            table: "Products",
+            column: "SKU",
+            unique: true,
+            filter: "[SKU] IS NOT NULL");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Products_SubcategoryId_Slug",
+            table: "Products",
+            columns: new[] { "SubcategoryId", "Slug" },
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Products_SupplierId",
+            table: "Products",
+            column: "SupplierId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Shifts_ClosedByUserId",
+            table: "Shifts",
+            column: "ClosedByUserId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Shifts_StoreId",
+            table: "Shifts",
+            column: "StoreId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Shifts_UserId",
+            table: "Shifts",
+            column: "UserId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Subcategories_CategoryId",
+            table: "Subcategories",
+            column: "CategoryId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Users_Email",
+            table: "Users",
+            column: "Email",
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Users_Pin",
+            table: "Users",
+            column: "Pin",
+            filter: "[Pin] IS NOT NULL");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Users_StoreId",
+            table: "Users",
+            column: "StoreId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Users_Username",
+            table: "Users",
+            column: "Username",
+            unique: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "InventoryTransactions");
+
+        migrationBuilder.DropTable(
+            name: "OrderItems");
+
+        migrationBuilder.DropTable(
+            name: "Payments");
+
+        migrationBuilder.DropTable(
+            name: "Products");
+
+        migrationBuilder.DropTable(
+            name: "Orders");
+
+        migrationBuilder.DropTable(
+            name: "Subcategories");
+
+        migrationBuilder.DropTable(
+            name: "Suppliers");
+
+        migrationBuilder.DropTable(
+            name: "Customers");
+
+        migrationBuilder.DropTable(
+            name: "Shifts");
+
+        migrationBuilder.DropTable(
+            name: "Categories");
+
+        migrationBuilder.DropTable(
+            name: "Users");
+
+        migrationBuilder.DropTable(
+            name: "Stores");
+    }
+}

--- a/backend/src/POS.Infrastructure/Data/Migrations/POSDbContextModelSnapshot.cs
+++ b/backend/src/POS.Infrastructure/Data/Migrations/POSDbContextModelSnapshot.cs
@@ -1,0 +1,1291 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using POS.Infrastructure.Data;
+
+#nullable disable
+
+namespace POS.Infrastructure.Data.Migrations;
+
+[DbContext(typeof(POSDbContext))]
+partial class POSDbContextModelSnapshot : ModelSnapshot
+{
+    protected override void BuildModel(ModelBuilder modelBuilder)
+    {
+        modelBuilder
+            .HasAnnotation("ProductVersion", "9.0.0")
+            .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+        SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+        modelBuilder.Entity("POS.Domain.Entities.Category", b =>
+        {
+            b.Property<long>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("bigint");
+
+            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+
+            b.Property<string>("Description")
+                .HasMaxLength(500)
+                .HasColumnType("nvarchar(500)");
+
+            b.Property<int>("DisplayOrder")
+                .HasColumnType("int");
+
+            b.Property<string>("Name")
+                .IsRequired()
+                .HasMaxLength(100)
+                .HasColumnType("nvarchar(100)");
+
+            b.Property<bool>("IsActive")
+                .HasColumnType("bit");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit");
+
+            b.Property<string>("Slug")
+                .IsRequired()
+                .HasMaxLength(100)
+                .HasColumnType("nvarchar(100)");
+
+            b.Property<DateTime?>("DeletedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("DeletedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime>("CreatedOn")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("datetime2")
+                .HasDefaultValueSql("GETUTCDATE()");
+
+            b.Property<long?>("CreatedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("ModifiedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("ModifiedByUserId")
+                .HasColumnType("bigint");
+
+            b.HasKey("Id");
+
+            b.HasIndex("Slug")
+                .IsUnique();
+
+            b.ToTable("Categories", (string)null);
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Customer", b =>
+        {
+            b.Property<long>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("bigint");
+
+            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+
+            b.Property<string>("Address")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("City")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<DateTime?>("DateOfBirth")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("DeletedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("DeletedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("Email")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("FirstName")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<bool>("IsActive")
+                .HasColumnType("bit");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit");
+
+            b.Property<DateTime?>("LastOrderDate")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("LastName")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<int>("LoyaltyPoints")
+                .HasColumnType("int");
+
+            b.Property<string>("LoyaltyCardNumber")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Notes")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Phone")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("PostalCode")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Country")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<decimal>("TotalPurchases")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<int>("TotalOrders")
+                .HasColumnType("int");
+
+            b.Property<long?>("CreatedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime>("CreatedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("ModifiedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("ModifiedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("State")
+                .HasColumnType("nvarchar(max)");
+
+            b.HasKey("Id");
+
+            b.ToTable("Customers", (string)null);
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.InventoryTransaction", b =>
+        {
+            b.Property<long>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("bigint");
+
+            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+
+            b.Property<long?>("CreatedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime>("CreatedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("DeletedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("DeletedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("ModifiedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("ModifiedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("Notes")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<long?>("OrderId")
+                .HasColumnType("bigint");
+
+            b.Property<long>("ProductId")
+                .HasColumnType("bigint");
+
+            b.Property<string>("ReferenceNumber")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<long>("StoreId")
+                .HasColumnType("bigint");
+
+            b.Property<long?>("SupplierId")
+                .HasColumnType("bigint");
+
+            b.Property<int>("Quantity")
+                .HasColumnType("int");
+
+            b.Property<int>("StockAfter")
+                .HasColumnType("int");
+
+            b.Property<int>("StockBefore")
+                .HasColumnType("int");
+
+            b.Property<int>("TransactionType")
+                .HasColumnType("int");
+
+            b.Property<DateTime>("TransactionDate")
+                .HasColumnType("datetime2");
+
+            b.Property<decimal?>("TotalCost")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<long>("UserId")
+                .HasColumnType("bigint");
+
+            b.Property<decimal?>("UnitCost")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit");
+
+            b.HasKey("Id");
+
+            b.HasIndex("OrderId");
+
+            b.HasIndex("ProductId");
+
+            b.HasIndex("StoreId");
+
+            b.HasIndex("SupplierId");
+
+            b.HasIndex("UserId");
+
+            b.ToTable("InventoryTransactions", (string)null);
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Order", b =>
+        {
+            b.Property<long>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("bigint");
+
+            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+
+            b.Property<decimal>("ChangeAmount")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<DateTime?>("CompletedAt")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("CreatedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime>("CreatedOn")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("datetime2")
+                .HasDefaultValueSql("GETUTCDATE()");
+
+            b.Property<long?>("CustomerId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("CancelledAt")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("CancellationReason")
+                .HasMaxLength(500)
+                .HasColumnType("nvarchar(500)");
+
+            b.Property<decimal>("DiscountAmount")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit");
+
+            b.Property<DateTime?>("ModifiedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("ModifiedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<string>("Notes")
+                .HasMaxLength(500)
+                .HasColumnType("nvarchar(500)");
+
+            b.Property<DateTime>("OrderDate")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("OrderNumber")
+                .IsRequired()
+                .HasMaxLength(50)
+                .HasColumnType("nvarchar(50)");
+
+            b.Property<int>("OrderType")
+                .HasColumnType("int");
+
+            b.Property<decimal>("PaidAmount")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<long?>("ShiftId")
+                .HasColumnType("bigint");
+
+            b.Property<long>("StoreId")
+                .HasColumnType("bigint");
+
+            b.Property<decimal>("SubTotal")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<decimal>("TaxAmount")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<string>("TableNumber")
+                .HasMaxLength(20)
+                .HasColumnType("nvarchar(20)");
+
+            b.Property<decimal>("TotalAmount")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<int>("Status")
+                .HasColumnType("int");
+
+            b.Property<long>("UserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("DeletedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("DeletedByUserId")
+                .HasColumnType("bigint");
+
+            b.HasKey("Id");
+
+            b.HasIndex("CustomerId");
+
+            b.HasIndex("OrderDate");
+
+            b.HasIndex("OrderNumber")
+                .IsUnique();
+
+            b.HasIndex("ShiftId");
+
+            b.HasIndex("StoreId", "OrderDate");
+
+            b.HasIndex("UserId");
+
+            b.ToTable("Orders", (string)null);
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.OrderItem", b =>
+        {
+            b.Property<long>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("bigint");
+
+            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+
+            b.Property<long?>("CreatedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime>("CreatedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<decimal>("DiscountAmount")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit");
+
+            b.Property<bool>("IsVoided")
+                .HasColumnType("bit");
+
+            b.Property<long?>("ModifiedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("ModifiedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("Notes")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<long>("OrderId")
+                .HasColumnType("bigint");
+
+            b.Property<long>("ProductId")
+                .HasColumnType("bigint");
+
+            b.Property<int>("Quantity")
+                .HasColumnType("int");
+
+            b.Property<decimal>("SubTotal")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<decimal>("TaxAmount")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<decimal>("TotalAmount")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<decimal>("UnitGstAmount")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<decimal>("UnitPriceExGst")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<decimal>("UnitPriceIncGst")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<DateTime?>("VoidedAt")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("VoidedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<string>("VoidReason")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<long?>("DeletedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("DeletedOn")
+                .HasColumnType("datetime2");
+
+            b.HasKey("Id");
+
+            b.HasIndex("OrderId");
+
+            b.HasIndex("ProductId");
+
+            b.HasIndex("VoidedByUserId");
+
+            b.ToTable("OrderItems", (string)null);
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Payment", b =>
+        {
+            b.Property<long>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("bigint");
+
+            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+
+            b.Property<decimal>("Amount")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<string>("CardLastFourDigits")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("CardType")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<long?>("CreatedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime>("CreatedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("DeletedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("DeletedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("ModifiedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("ModifiedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("Notes")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<long>("OrderId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime>("PaymentDate")
+                .HasColumnType("datetime2");
+
+            b.Property<int>("PaymentMethod")
+                .HasColumnType("int");
+
+            b.Property<long>("ProcessedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<string>("ReferenceNumber")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<int>("Status")
+                .HasColumnType("int");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit");
+
+            b.HasKey("Id");
+
+            b.HasIndex("OrderId");
+
+            b.HasIndex("ProcessedByUserId");
+
+            b.ToTable("Payments", (string)null);
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Product", b =>
+        {
+            b.Property<long>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("bigint");
+
+            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+
+            b.Property<long?>("CreatedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime>("CreatedOn")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("datetime2")
+                .HasDefaultValueSql("GETUTCDATE()");
+
+            b.Property<bool>("IsActive")
+                .HasColumnType("bit");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit");
+
+            b.Property<bool>("TrackInventory")
+                .HasColumnType("bit");
+
+            b.Property<int>("DisplayOrder")
+                .HasColumnType("int");
+
+            b.Property<string>("Description")
+                .HasMaxLength(1000)
+                .HasColumnType("nvarchar(1000)");
+
+            b.Property<long?>("DeletedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("DeletedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<int?>("PackSize")
+                .HasColumnType("int");
+
+            b.Property<string>("PackNotes")
+                .HasMaxLength(200)
+                .HasColumnType("nvarchar(200)");
+
+            b.Property<int>("LowStockThreshold")
+                .HasColumnType("int");
+
+            b.Property<string>("ImageUrl")
+                .HasMaxLength(500)
+                .HasColumnType("nvarchar(500)");
+
+            b.Property<int>("StockQuantity")
+                .HasColumnType("int");
+
+            b.Property<string>("Name")
+                .IsRequired()
+                .HasMaxLength(200)
+                .HasColumnType("nvarchar(200)");
+
+            b.Property<string>("Slug")
+                .IsRequired()
+                .HasMaxLength(200)
+                .HasColumnType("nvarchar(200)");
+
+            b.Property<string>("SKU")
+                .HasMaxLength(50)
+                .HasColumnType("nvarchar(50)");
+
+            b.Property<string>("Barcode")
+                .HasMaxLength(50)
+                .HasColumnType("nvarchar(50)");
+
+            b.Property<decimal?>("Cost")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<decimal>("GstAmount")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<long?>("ModifiedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("ModifiedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<decimal>("PriceExGst")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<decimal>("PriceIncGst")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<long>("SubcategoryId")
+                .HasColumnType("bigint");
+
+            b.Property<long?>("SupplierId")
+                .HasColumnType("bigint");
+
+            b.HasKey("Id");
+
+            b.HasIndex("Barcode")
+                .IsUnique()
+                .HasFilter("[Barcode] IS NOT NULL");
+
+            b.HasIndex("SKU")
+                .IsUnique()
+                .HasFilter("[SKU] IS NOT NULL");
+
+            b.HasIndex("SupplierId");
+
+            b.HasIndex("SubcategoryId", "Slug")
+                .IsUnique();
+
+            b.ToTable("Products", (string)null);
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Shift", b =>
+        {
+            b.Property<long>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("bigint");
+
+            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+
+            b.Property<long?>("ClosedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<decimal?>("CardSales")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<decimal?>("CashSales")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<DateTime?>("EndTime")
+                .HasColumnType("datetime2");
+
+            b.Property<decimal?>("EndingCash")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit");
+
+            b.Property<string>("Notes")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<decimal?>("OtherSales")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<int?>("TotalOrders")
+                .HasColumnType("int");
+
+            b.Property<decimal?>("TotalSales")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<int>("Status")
+                .HasColumnType("int");
+
+            b.Property<long>("StoreId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime>("StartTime")
+                .HasColumnType("datetime2");
+
+            b.Property<decimal>("StartingCash")
+                .HasPrecision(18, 2)
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<string>("ShiftNumber")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<long>("UserId")
+                .HasColumnType("bigint");
+
+            b.Property<long?>("CreatedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime>("CreatedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("DeletedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("DeletedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("ModifiedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("ModifiedOn")
+                .HasColumnType("datetime2");
+
+            b.HasKey("Id");
+
+            b.HasIndex("ClosedByUserId");
+
+            b.HasIndex("StoreId");
+
+            b.HasIndex("UserId");
+
+            b.ToTable("Shifts", (string)null);
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Store", b =>
+        {
+            b.Property<long>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("bigint");
+
+            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+
+            b.Property<string>("Address")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("City")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Code")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Country")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<long?>("CreatedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime>("CreatedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("Currency")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<long?>("DeletedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("DeletedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("Email")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<bool>("IsActive")
+                .HasColumnType("bit");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit");
+
+            b.Property<TimeSpan?>("ClosingTime")
+                .HasColumnType("time");
+
+            b.Property<TimeSpan?>("OpeningTime")
+                .HasColumnType("time");
+
+            b.Property<string>("Name")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Phone")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("PostalCode")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<decimal>("TaxRate")
+                .HasPrecision(5, 4)
+                .HasColumnType("decimal(5,4)");
+
+            b.Property<string>("TaxNumber")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<long?>("ModifiedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("ModifiedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("State")
+                .HasColumnType("nvarchar(max)");
+
+            b.HasKey("Id");
+
+            b.ToTable("Stores", (string)null);
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Subcategory", b =>
+        {
+            b.Property<long>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("bigint");
+
+            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+
+            b.Property<long>("CategoryId")
+                .HasColumnType("bigint");
+
+            b.Property<long?>("CreatedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime>("CreatedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("Description")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<int>("DisplayOrder")
+                .HasColumnType("int");
+
+            b.Property<bool>("IsActive")
+                .HasColumnType("bit");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit");
+
+            b.Property<long?>("DeletedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("DeletedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<long?>("ModifiedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("ModifiedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("Name")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Slug")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.HasKey("Id");
+
+            b.HasIndex("CategoryId");
+
+            b.ToTable("Subcategories", (string)null);
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Supplier", b =>
+        {
+            b.Property<long>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("bigint");
+
+            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+
+            b.Property<string>("Address")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("City")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("ContactPerson")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<long?>("CreatedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime>("CreatedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("Country")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<long?>("DeletedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("DeletedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("Email")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<bool>("IsActive")
+                .HasColumnType("bit");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit");
+
+            b.Property<string>("Name")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Notes")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Phone")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("PostalCode")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<long?>("ModifiedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("ModifiedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("State")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("TaxNumber")
+                .HasColumnType("nvarchar(max)");
+
+            b.HasKey("Id");
+
+            b.ToTable("Suppliers", (string)null);
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.User", b =>
+        {
+            b.Property<long>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("bigint");
+
+            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+
+            b.Property<long?>("CreatedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime>("CreatedOn")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("datetime2")
+                .HasDefaultValueSql("GETUTCDATE()");
+
+            b.Property<string>("Email")
+                .IsRequired()
+                .HasMaxLength(100)
+                .HasColumnType("nvarchar(100)");
+
+            b.Property<string>("FirstName")
+                .IsRequired()
+                .HasMaxLength(50)
+                .HasColumnType("nvarchar(50)");
+
+            b.Property<bool>("IsActive")
+                .HasColumnType("bit");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit");
+
+            b.Property<DateTime?>("LastLoginAt")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("LastName")
+                .IsRequired()
+                .HasMaxLength(50)
+                .HasColumnType("nvarchar(50)");
+
+            b.Property<long?>("ModifiedByUserId")
+                .HasColumnType("bigint");
+
+            b.Property<DateTime?>("ModifiedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("PasswordHash")
+                .IsRequired()
+                .HasMaxLength(500)
+                .HasColumnType("nvarchar(500)");
+
+            b.Property<string>("Phone")
+                .HasMaxLength(20)
+                .HasColumnType("nvarchar(20)");
+
+            b.Property<string>("Pin")
+                .HasMaxLength(10)
+                .HasColumnType("nvarchar(10)");
+
+            b.Property<string>("RefreshToken")
+                .HasMaxLength(500)
+                .HasColumnType("nvarchar(500)");
+
+            b.Property<DateTime?>("RefreshTokenExpiryTime")
+                .HasColumnType("datetime2");
+
+            b.Property<int>("Role")
+                .HasColumnType("int");
+
+            b.Property<long?>("StoreId")
+                .HasColumnType("bigint");
+
+            b.Property<string>("Username")
+                .IsRequired()
+                .HasMaxLength(50)
+                .HasColumnType("nvarchar(50)");
+
+            b.HasKey("Id");
+
+            b.HasIndex("Email")
+                .IsUnique();
+
+            b.HasIndex("Pin")
+                .HasFilter("[Pin] IS NOT NULL");
+
+            b.HasIndex("StoreId");
+
+            b.HasIndex("Username")
+                .IsUnique();
+
+            b.ToTable("Users", (string)null);
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.InventoryTransaction", b =>
+        {
+            b.HasOne("POS.Domain.Entities.Order", "Order")
+                .WithMany()
+                .HasForeignKey("OrderId")
+                .OnDelete(DeleteBehavior.Restrict);
+
+            b.HasOne("POS.Domain.Entities.Product", "Product")
+                .WithMany("InventoryTransactions")
+                .HasForeignKey("ProductId")
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            b.HasOne("POS.Domain.Entities.Store", "Store")
+                .WithMany("InventoryTransactions")
+                .HasForeignKey("StoreId")
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            b.HasOne("POS.Domain.Entities.Supplier", "Supplier")
+                .WithMany()
+                .HasForeignKey("SupplierId")
+                .OnDelete(DeleteBehavior.SetNull);
+
+            b.HasOne("POS.Domain.Entities.User", "User")
+                .WithMany()
+                .HasForeignKey("UserId")
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            b.Navigation("Order");
+
+            b.Navigation("Product");
+
+            b.Navigation("Store");
+
+            b.Navigation("Supplier");
+
+            b.Navigation("User");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Order", b =>
+        {
+            b.HasOne("POS.Domain.Entities.Customer", "Customer")
+                .WithMany("Orders")
+                .HasForeignKey("CustomerId")
+                .OnDelete(DeleteBehavior.SetNull);
+
+            b.HasOne("POS.Domain.Entities.Shift", "Shift")
+                .WithMany("Orders")
+                .HasForeignKey("ShiftId")
+                .OnDelete(DeleteBehavior.SetNull);
+
+            b.HasOne("POS.Domain.Entities.Store", "Store")
+                .WithMany("Orders")
+                .HasForeignKey("StoreId")
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            b.HasOne("POS.Domain.Entities.User", "User")
+                .WithMany("Orders")
+                .HasForeignKey("UserId")
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            b.Navigation("Customer");
+
+            b.Navigation("Shift");
+
+            b.Navigation("Store");
+
+            b.Navigation("User");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.OrderItem", b =>
+        {
+            b.HasOne("POS.Domain.Entities.Order", "Order")
+                .WithMany("OrderItems")
+                .HasForeignKey("OrderId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+
+            b.HasOne("POS.Domain.Entities.Product", "Product")
+                .WithMany("OrderItems")
+                .HasForeignKey("ProductId")
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            b.HasOne("POS.Domain.Entities.User", "VoidedByUser")
+                .WithMany()
+                .HasForeignKey("VoidedByUserId")
+                .OnDelete(DeleteBehavior.Restrict);
+
+            b.Navigation("Order");
+
+            b.Navigation("Product");
+
+            b.Navigation("VoidedByUser");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Payment", b =>
+        {
+            b.HasOne("POS.Domain.Entities.Order", "Order")
+                .WithMany("Payments")
+                .HasForeignKey("OrderId")
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            b.HasOne("POS.Domain.Entities.User", "ProcessedByUser")
+                .WithMany()
+                .HasForeignKey("ProcessedByUserId")
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            b.Navigation("Order");
+
+            b.Navigation("ProcessedByUser");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Product", b =>
+        {
+            b.HasOne("POS.Domain.Entities.Subcategory", "Subcategory")
+                .WithMany("Products")
+                .HasForeignKey("SubcategoryId")
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            b.HasOne("POS.Domain.Entities.Supplier", "Supplier")
+                .WithMany("Products")
+                .HasForeignKey("SupplierId")
+                .OnDelete(DeleteBehavior.SetNull);
+
+            b.Navigation("Subcategory");
+
+            b.Navigation("Supplier");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Shift", b =>
+        {
+            b.HasOne("POS.Domain.Entities.User", "ClosedByUser")
+                .WithMany()
+                .HasForeignKey("ClosedByUserId")
+                .OnDelete(DeleteBehavior.Restrict);
+
+            b.HasOne("POS.Domain.Entities.Store", "Store")
+                .WithMany("Shifts")
+                .HasForeignKey("StoreId")
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            b.HasOne("POS.Domain.Entities.User", "User")
+                .WithMany("Shifts")
+                .HasForeignKey("UserId")
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            b.Navigation("ClosedByUser");
+
+            b.Navigation("Store");
+
+            b.Navigation("User");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Subcategory", b =>
+        {
+            b.HasOne("POS.Domain.Entities.Category", "Category")
+                .WithMany("Subcategories")
+                .HasForeignKey("CategoryId")
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            b.Navigation("Category");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.User", b =>
+        {
+            b.HasOne("POS.Domain.Entities.Store", "Store")
+                .WithMany("Users")
+                .HasForeignKey("StoreId")
+                .OnDelete(DeleteBehavior.SetNull);
+
+            b.Navigation("Store");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Category", b =>
+        {
+            b.Navigation("Subcategories");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Customer", b =>
+        {
+            b.Navigation("Orders");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Order", b =>
+        {
+            b.Navigation("OrderItems");
+
+            b.Navigation("Payments");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Product", b =>
+        {
+            b.Navigation("InventoryTransactions");
+
+            b.Navigation("OrderItems");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Shift", b =>
+        {
+            b.Navigation("Orders");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Store", b =>
+        {
+            b.Navigation("InventoryTransactions");
+
+            b.Navigation("Orders");
+
+            b.Navigation("Shifts");
+
+            b.Navigation("Users");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Subcategory", b =>
+        {
+            b.Navigation("Products");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.Supplier", b =>
+        {
+            b.Navigation("Products");
+        });
+
+        modelBuilder.Entity("POS.Domain.Entities.User", b =>
+        {
+            b.Navigation("Orders");
+
+            b.Navigation("Shifts");
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add explicit decimal precision mappings for customer, inventory transaction, order item, payment, shift, and store monetary fields to avoid SQL truncation
- unignore the infrastructure migrations folder and add an initial EF Core migration plus model snapshot so the database schema matches the current model

## Testing
- `dotnet build` *(fails: .NET SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce08523e4883308c76b88c81909abe